### PR TITLE
Change the assert check for kdfrounds and bump default rounds to 2^7

### DIFF
--- a/signify/pure.py
+++ b/signify/pure.py
@@ -236,7 +236,7 @@ class SecretKey(_Materialized):
 
             assert pkalg == b'Ed'
             assert kdfalg == b'BK'
-            assert kdfrounds in [0, 42]
+            assert kdfrounds >= 0 and kdfrounds <= 2**31
         except Exception as e:
             raise SignifyError(e)
 
@@ -368,7 +368,9 @@ def generate_from_raw(comment, password, raw_pub, raw_priv):
     keynum = os.urandom(8)
 
     # private key
-    kdfrounds = 42
+    # see _bcrypt_autorounds() in OpenBSD:src/lib/libc/crypt/bcrypt.c if you
+    # want to change number of rounds to something that matches your machine
+    kdfrounds = 2**7
     salt = os.urandom(16)
 
     if password is None:

--- a/test/pure_test.py
+++ b/test/pure_test.py
@@ -26,7 +26,18 @@ RWQ100QRGZoxU/gjzE8m6GYtfICqE0Ap8SdXRSHrpjnSBKMc2RMXlgi5RKrEHmKfTmcsuB9ZzDCo6K6s
             'embedded': b"""untrusted comment: signature from bjorntest secret key
 RWQ100QRGZoxU/gjzE8m6GYtfICqE0Ap8SdXRSHrpjnSBKMc2RMalgi5RKrEHmKfTmcsuB9ZzDCo6K6sYEqaEcEnnAFa0zCewAg=
 my message
-"""
+""",
+            'priv128': b"""untrusted comment: signify secret key 128 rounds
+RWRCSwAAAIBK/82p6+aolZQUgs7+JP0Fssf+TPHDVC316WVHxrWWJx4W4cy8wTy9FKGCSNBMvTII0cddRe3Ls0TWBfwOHOSgOJ7GcF9zfmDeqMM63lRcObSY48BkOCz1gqOTvcSGvos=
+""",
+            'pub128': b"""untrusted comment: public key for priv128 key
+untrusted comment: signify public key
+RWT16WVHxrWWJzuyLW1zO7uTWPPejer1uX0PX4Y/1bkwaDgnbeU6dHnL
+""",
+            'embedded128': b"""untrusted comment: signature from signify secret key 128 rounds
+RWT16WVHxrWWJ2fhavXHp1SDGZLzI8vpNxWyvbzXYIptU/L5xzZ/Sq+yDwFJ3u8W1Xi4CmEy+0xfM59dk/yVp6MLAifaGG9obQI=
+my message
+""",
             }
         ]
 
@@ -120,6 +131,16 @@ my message
             signify.verify(pub,
                            sig,
                            b'My Message'))
+
+
+    def test_sign_embedded_128_rounds(self):
+        sk = signify.SecretKey.from_bytes(self.KAT[0]['priv128'])
+        sku = sk.unprotect('foobar')
+        sig = signify.sign(sku,
+                           self.KAT[0]['message'],
+                           True)
+
+        self.assertEquals(self.KAT[0]['embedded128'], sig.to_bytes())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The assert before checked if kdfrounds was 0 or 42 but people might want to bump it
and still support older formats.

py-bcrypt warns for anything below 50 so bumping to 128 also gets rid of a runtime warning:

/usr/local/lib/python2.7/dist-packages/bcrypt-3.1.3-py2.7-linux-x86_64.egg/bcrypt/__init__.py:137: UserWarning: Warning: bcrypt.kdf() called with only 42 round(s). This few is not secure: the parameter is linear, like PBKDF2.