### PR TITLE
Fix checksum calculation by checking length of read buffer

### DIFF
--- a/signify/check.py
+++ b/signify/check.py
@@ -17,7 +17,7 @@ def hash_file(hashobj, path):
         while True:
             buf = fobj.read(BUFSIZE)
             hashobj.update(buf)
-            if buf != BUFSIZE:
+            if len(buf) != BUFSIZE:
                 break
     return True
 


### PR DESCRIPTION
This fixes all checksum calculations of files above BUFSIZE (64K)