### PR TITLE
signi.py: checkfiles expects a string, not a bytes-like object

### DIFF
--- a/bin/signi.py
+++ b/bin/signi.py
@@ -117,7 +117,7 @@ def main():
             sys.exit(1)
 
         exit_fail = False
-        for path, status in check.checkfiles(os.getcwd(), message):
+        for path, status in check.checkfiles(os.getcwd(), message.decode('utf-8')):
             if args.path:
                 include = (path in args.path)
             else:


### PR DESCRIPTION
This matches what is done here: https://github.com/bjornedstrom/python-signify/blob/master/signify/pure.py#L440

before:
```
# signi.py -C -p ./dude.pub -x SHA256.sig
Signature Verified
Traceback (most recent call last):
  File "/usr/bin/signi.py", line 181, in <module>
    main()
  File "/usr/bin/signi.py", line 121, in main
    for path, status in check.checkfiles(os.getcwd(), message):
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/signify/check.py", line 36, in checkfiles
    for algo, path, ref_digest in re.findall(
                                  ^^^^^^^^^^^
  File "/usr/lib64/python3.12/re/__init__.py", line 217, in findall
    return _compile(pattern, flags).findall(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: cannot use a string pattern on a bytes-like object
```

after:
```
# signi.py -C -p ./dude.pub -x SHA256.sig
Signature Verified
foo.pem: OK
bar.pem: OK
```

SHA256.sig looks like this:
```
# cat SHA256.sig
untrusted comment: signature from dude
RWTp/neG79aK6il7+KDR7gHdmJMt1CM8gt67ijEtupMg4u+qybNv23qPleuvBiLQ/rC3OccwI8opQkBAg/zB+H8PYCvnfb8B2gg=
SHA256 (foo.pem) = ae30f85e075085b4110de3d4a97483e45339ff2776196b6146dc3b10db7cbe9c
SHA256 (bar.pem) = 4d4d734dd38ca49e6364f3aaac0bde028f11620028448aa64320c79d7a742e61
```